### PR TITLE
ci: add Qwen3.6-Plus PR review (static + opencode)

### DIFF
--- a/.github/workflows/qwen-review.yml
+++ b/.github/workflows/qwen-review.yml
@@ -1,0 +1,116 @@
+name: qwen-review
+
+# Self-hosted PR review using Alibaba Bailian Coding Plan (Qwen3.6 Plus) via opencode.
+# Two INDEPENDENT jobs:
+#   - static:   fast static analysis (Python/TS/Rust). Report-only, never blocks.
+#   - opencode: LLM review with Qwen3.6 Plus. Has NO `needs:` on static, so it
+#               runs no matter what — even if static fails or is skipped.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+  id-token: write
+
+concurrency:
+  group: qwen-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Static analysis — quick tools only (uv / bun / cargo). Advisory: every step
+  # is `|| true` so this job is informational and can never block the LLM review.
+  # ---------------------------------------------------------------------------
+  static:
+    name: Static analysis (uv / bun / cargo)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: latest
+
+      - name: Install bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Python — ruff (lint + format check)
+        run: |
+          if git ls-files '*.py' | grep -q .; then
+            echo "::group::ruff check"
+            uvx ruff check --output-format=github . || true
+            echo "::endgroup::"
+            echo "::group::ruff format --check"
+            uvx ruff format --check . || true
+            echo "::endgroup::"
+          else
+            echo "No Python files; skipping."
+          fi
+
+      - name: TypeScript / JavaScript — biome + tsc
+        run: |
+          if git ls-files '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs' | grep -q .; then
+            echo "::group::biome ci"
+            bunx --bun @biomejs/biome ci --diagnostic-level=error . || true
+            echo "::endgroup::"
+            if [ -f tsconfig.json ]; then
+              echo "::group::tsc --noEmit"
+              bunx --bun typescript tsc --noEmit || true
+              echo "::endgroup::"
+            fi
+          else
+            echo "No TS/JS files; skipping."
+          fi
+
+      - name: Rust — fmt + clippy
+        run: |
+          if git ls-files '*.rs' | grep -q .; then
+            rustup component add clippy rustfmt 2>/dev/null || true
+            echo "::group::cargo fmt --check"
+            cargo fmt --all --check || true
+            echo "::endgroup::"
+            echo "::group::cargo clippy"
+            cargo clippy --all-targets --all-features -- -W clippy::all || true
+            echo "::endgroup::"
+          else
+            echo "No Rust files; skipping."
+          fi
+
+  # ---------------------------------------------------------------------------
+  # LLM review — Qwen3.6 Plus via opencode + the Bailian OpenAI-compatible API.
+  # Independent job (no `needs:`): runs even when `static` fails.
+  # ---------------------------------------------------------------------------
+  opencode:
+    name: opencode review (Qwen3.6 Plus)
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: dashscope/qwen3.6-plus
+          use_github_token: true
+          share: "false"
+          prompt: |
+            Review this pull request as a senior engineer. Be concise and specific.
+            - Flag correctness bugs, security issues, and data-loss risks first.
+            - Note Python / TypeScript / Rust issues a linter would miss (logic, API misuse, races).
+            - Call out missing tests for changed behavior.
+            - Skip nitpicks already covered by formatters/linters.
+            Post a single review comment grouped by severity (Blocking / Should-fix / Nit).

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "dashscope": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "DashScope (Alibaba Bailian Coding Plan)",
+      "options": {
+        "baseURL": "https://coding-intl.dashscope.aliyuncs.com/v1",
+        "apiKey": "{env:DASHSCOPE_API_KEY}"
+      },
+      "models": {
+        "qwen3.6-plus": {
+          "name": "Qwen3.6 Plus"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### **User description**
Self-hosted PR reviewer (Qwen3.6 Plus via Bailian). static job is advisory; opencode job runs independently. 🤖 Generated with Claude Code


___

### **PR Type**
Enhancement


___

### **Description**
- Add self-hosted PR review workflow using Qwen3.6 Plus LLM

- Implement independent static analysis job (Python/TS/Rust)

- Configure opencode integration with Alibaba Bailian API

- Enable concurrent PR reviews with automatic cancellation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PR["Pull Request<br/>opened/sync/reopen"] --> STATIC["Static Analysis<br/>ruff/biome/cargo"]
  PR --> OPENCODE["LLM Review<br/>Qwen3.6 Plus"]
  STATIC --> REPORT1["Advisory Report"]
  OPENCODE --> REVIEW["PR Comment<br/>Blocking/Should-fix/Nit"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>qwen-review.yml</strong><dd><code>GitHub Actions workflow for Qwen3.6 Plus PR review</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/qwen-review.yml

<ul><li>Defines two independent CI jobs: static analysis and LLM-based code <br>review<br> <li> Static job runs linters (ruff, biome, tsc, cargo fmt/clippy) with <br>non-blocking results<br> <li> Opencode job invokes Qwen3.6 Plus model via Alibaba Bailian API for <br>intelligent PR review<br> <li> Implements concurrency control to cancel in-progress reviews for <br>duplicate PRs</ul>


</details>


  </td>
  <td><a href="https://github.com/cicero-im/fiduswriter/pull/9/files#diff-de684ceb3ea23c178392732cbcc3d6dd4b6c663454cc366f0c8d125cb95c2b5b">+116/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>opencode.json</strong><dd><code>Opencode configuration for DashScope provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

opencode.json

<ul><li>Configures DashScope provider for Alibaba Bailian Coding Plan <br>integration<br> <li> Specifies Qwen3.6 Plus model endpoint and authentication via <br>environment variable<br> <li> Defines OpenAI-compatible API baseURL for model access</ul>


</details>


  </td>
  <td><a href="https://github.com/cicero-im/fiduswriter/pull/9/files#diff-33b8bb80766a21fd5894871ffb6e9be4bd034d870629e385cfeecc4589df3bf2">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

## Summary by Sourcery

Introduce a self-hosted Qwen3.6 Plus–based PR review workflow with separate static analysis and LLM review jobs for pull requests.

New Features:
- Add a GitHub Actions workflow that runs advisory static analysis and an independent LLM-based PR review on pull requests using Qwen3.6 Plus via Alibaba Bailian.

Enhancements:
- Configure non-blocking static analysis for Python, TypeScript/JavaScript, and Rust using uv, bun, and cargo tooling.
- Enable concurrent LLM PR reviews with concurrency control to cancel in-progress runs for the same pull request.
- Add opencode configuration to integrate with DashScope/Bailian using an OpenAI-compatible endpoint and secret-based authentication.

CI:
- Add a qwen-review GitHub Actions workflow with static and opencode jobs triggered on pull request events.